### PR TITLE
Fix deallocating vector memory

### DIFF
--- a/Numeric/LBFGS.hs
+++ b/Numeric/LBFGS.hs
@@ -288,6 +288,6 @@ lbfgs_ lbfgsParams evalFun progressFun inst p = do
   freeHaskellFunPtr evalW
   free paramP
   freeStablePtr instP
-  freeVector pVec
   rl <- vectorToList n pVec
+  freeVector pVec
   return (deriveResult $ CLBFGSResult r, rl)


### PR DESCRIPTION
Parameters vector was incorrectly deallocated before values were extracted. This caused function to return garbage as a result.